### PR TITLE
Added CJK tokenization support

### DIFF
--- a/core/src/cjk.rs
+++ b/core/src/cjk.rs
@@ -1,0 +1,127 @@
+/// CJK (Chinese, Japanese, Korean) tokenization support.
+
+pub fn is_cjk_char(c: char) -> bool {
+    matches!(c,
+        '\u{4E00}'..='\u{9FFF}'   // CJK Unified Ideographs
+        | '\u{3400}'..='\u{4DBF}' // CJK Extension A
+        | '\u{20000}'..='\u{2A6DF}' // CJK Extension B
+        | '\u{3040}'..='\u{309F}' // Hiragana
+        | '\u{30A0}'..='\u{30FF}' // Katakana
+        | '\u{AC00}'..='\u{D7AF}' // Hangul Syllables
+        | '\u{1100}'..='\u{11FF}' // Hangul Jamo
+    )
+}
+
+/// Returns `true` if `c` is a Hangul character (Korean).
+pub fn is_hangul_char(c: char) -> bool {
+    matches!(c,
+        '\u{AC00}'..='\u{D7AF}' // Hangul Syllables
+        | '\u{1100}'..='\u{11FF}' // Hangul Jamo
+    )
+}
+
+pub fn contains_cjk(text: &str) -> bool {
+    text.chars().any(is_cjk_char)
+}
+
+
+/// Used to decide whether to apply the space-split strategy instead of n-grams.
+pub fn is_predominantly_korean(text: &str) -> bool {
+    let mut hangul = 0usize;
+    let mut other_cjk = 0usize;
+    for c in text.chars() {
+        if is_hangul_char(c) {
+            hangul += 1;
+        } else if is_cjk_char(c) {
+            other_cjk += 1;
+        }
+    }
+    hangul > 0 && other_cjk == 0
+}
+
+// N-gram tokenizer for Chinese / Japanese
+
+pub fn tokenize_cjk(text: &str) -> Vec<String> {
+    let mut tokens: Vec<String> = Vec::new();
+
+    let mut run: Vec<char> = Vec::new();
+
+    let emit_run = |run: &[char], tokens: &mut Vec<String>| {
+        match run.len() {
+            0 => {}
+            1 => {
+                tokens.push(run[0].to_string());
+            }
+            2 => {
+                let s: String = run.iter().collect();
+                tokens.push(s);
+            }
+            n => {
+                for i in 0..n - 1 {
+                    let bigram: String = run[i..i + 2].iter().collect();
+                    tokens.push(bigram);
+                }
+                if n >= 3 {
+                    for i in 0..n - 2 {
+                        let trigram: String = run[i..i + 3].iter().collect();
+                        tokens.push(trigram);
+                    }
+                }
+            }
+        }
+    };
+
+    for c in text.chars() {
+        if is_cjk_char(c) && !is_hangul_char(c) {
+            run.push(c);
+        } else if !run.is_empty() {
+            emit_run(&run, &mut tokens);
+            run.clear();
+        }
+    }
+    if !run.is_empty() {
+        emit_run(&run, &mut tokens);
+    }
+
+    
+    tokens.into_iter().map(|t| t.to_lowercase()).collect()
+}
+
+// Korean tokenizer (space-split)
+
+pub fn split_korean(text: &str) -> Vec<String> {
+    text.split_whitespace()
+        .filter(|tok| tok.chars().any(is_hangul_char))
+        .map(|tok| {
+            let trimmed = tok.trim_matches(|c: char| c.is_ascii_punctuation());
+            trimmed.to_lowercase()
+        })
+        .filter(|tok| !tok.is_empty())
+        .collect()
+}
+
+// Mixed-language dispatch
+
+pub fn extract_cjk_keywords(text: &str) -> Vec<String> {
+    if !contains_cjk(text) {
+        return Vec::new();
+    }
+
+    let mut out: Vec<String> = Vec::new();
+
+    // N-gram tokens for Chinese/Japanese characters
+    let ngrams = tokenize_cjk(text);
+    out.extend(ngrams);
+
+    // Space-split tokens for Korean
+    let korean = split_korean(text);
+    out.extend(korean);
+
+    // Deduplicate while preserving order
+    let mut seen = std::collections::HashSet::new();
+    out.retain(|t| seen.insert(t.clone()));
+
+    out
+}
+
+

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,5 +1,7 @@
 use serde::{Deserialize, Serialize};
 
+pub mod cjk;
+
 #[cfg(any(feature = "cli", feature = "wasm", test))]
 use std::collections::HashMap;
 
@@ -155,7 +157,7 @@ pub fn build_index(documents: Vec<Document>) -> Result<Index, Box<dyn std::error
 			}
 		}
 
-		// add keywords from title
+		// add keywords from title (Latin words)
 		let title_keywords = doc
 			.title
 			.split_whitespace()
@@ -173,6 +175,15 @@ pub fn build_index(documents: Vec<Document>) -> Result<Index, Box<dyn std::error
 			}
 		}
 
+		// CJK keywords from the title (n-grams / Korean words)
+		for ck in cjk::extract_cjk_keywords(&doc.title) {
+			if !keyword_set.contains(&ck) {
+				keywords.push((ck.clone(), 90.0));
+				keyword_set.insert(ck);
+			}
+		}
+
+		// RAKE on the Latin portions of the body
 		let body_keywords = rake.run_fragments(vec![doc.body.as_str()]);
 		let mut single_word_budget = 5;
 		let mut double_word_budget = 3;
@@ -200,6 +211,15 @@ pub fn build_index(documents: Vec<Document>) -> Result<Index, Box<dyn std::error
 
 			if single_word_budget == 0 && double_word_budget == 0 {
 				break;
+			}
+		}
+
+		// CJK keywords from the body (n-grams for Chinese/Japanese,
+		// space-split for Korean)
+		for ck in cjk::extract_cjk_keywords(&doc.body) {
+			if !keyword_set.contains(&ck) {
+				keywords.push((ck.clone(), 70.0));
+				keyword_set.insert(ck);
 			}
 		}
 
@@ -255,6 +275,7 @@ pub fn search(
 
 	let map = fst::Map::new(&index.fst)?;
 
+	// Latin query words — split on whitespace and strip punctuation
 	let mut query_words: HashSet<String> = query
 		.split_whitespace()
 		.map(|w| {
@@ -266,9 +287,15 @@ pub fn search(
 
 	query_words.insert(query.to_lowercase());
 
+	// CJK query tokens — n-grams for Chinese/Japanese, space-split for Korean.
+	// These are looked up exactly (no Levenshtein) because the FST contains
+	// the same n-grams produced at index time.
+	let cjk_query_tokens = cjk::extract_cjk_keywords(query);
+
 	let mut keywords: Vec<(String, u64)> = Vec::new();
 
-	for query_word in query_words {
+	// --- Latin / mixed words: fuzzy + prefix lookup ---
+	for query_word in &query_words {
 		use fst::automaton::Str;
 
 		let lev = Levenshtein::new(query_word.as_str(), 1)?;
@@ -283,6 +310,13 @@ pub fn search(
 			let keyword_str = String::from_utf8(keyword.to_vec())?;
 			let score = indexed_value.to_vec().get(0).unwrap().value;
 			keywords.push((keyword_str, score));
+		}
+	}
+
+	// --- CJK tokens: exact lookup in the FST (n-grams must match exactly) ---
+	for cjk_token in &cjk_query_tokens {
+		if let Some(idx) = map.get(cjk_token.as_str()) {
+			keywords.push((cjk_token.clone(), idx));
 		}
 	}
 


### PR DESCRIPTION
This PR introduces native tokenization and search capabilities for CJK languages by adding core/src/cjk.rs
and integrating it into the core pipeline.

Key additions in cjk.rs:

- **Character Detection:** Added utilities (is_cjk_char, is_hangul_char) to accurately detect and classify Chinese, Japanese, and Korean text.
- N-Gram Tokenization (Chinese/Japanese): Implemented an overlapping N-gram extraction strategy (generating bi-grams and tri-grams) to effectively tokenize continuous, unspaced Chinese and Japanese strings.
- **Whitespace Tokenization (Korean):** Added a dedicated space-splitting strategy for Korean (Hangul),correctly stripping punctuation to extract meaningful keywords.
- **Mixed-Language Processing:** Introduced an extract_cjk_keywords orchestrator that gracefully handles text containing mixed CJK characters and languages, merging and deduplicating both n-gram and space-split output tokens.
<img width="953" height="417" alt="Screenshot 2026-03-11 at 14 20 28" src="https://github.com/user-attachments/assets/15a8da1c-6d97-4d4c-bb22-c8c14de4dfb4" />
